### PR TITLE
Detect downloads with too many nodes

### DIFF
--- a/src/org/openstreetmap/josm/plugins/continuosDownload/AbstractDownloadStrategy.java
+++ b/src/org/openstreetmap/josm/plugins/continuosDownload/AbstractDownloadStrategy.java
@@ -125,6 +125,9 @@ public abstract class AbstractDownloadStrategy {
 
     private static void download(Collection<Bounds> bboxes, Class<?> klass) {
         for (Bounds bbox : bboxes) {
+            // This returns a task that has been started on a worker thread.
+            // if DownloadOsmTask2, it is on DownloadPlugin.worker
+            // Otherwise, it is on MainApplication.worker
             AbstractDownloadTask<?> task = getDownloadTask(klass);
             
             ProgressMonitor monitor = null;
@@ -133,7 +136,9 @@ public abstract class AbstractDownloadStrategy {
             }
 
             Future<?> future = task.download(new DownloadParams(), bbox, monitor);
-            DownloadPlugin.worker.execute(new PostDownloadHandler(task, future));
+            // Run the PostDownloadHandler on the main worker thread.
+            // This should tend to be the bit where we may run into concurrent modification exceptions.
+            MainApplication.worker.execute(new PostDownloadHandler(task, future));
         }
     }
 

--- a/src/org/openstreetmap/josm/plugins/continuosDownload/DownloadOsmTask2.java
+++ b/src/org/openstreetmap/josm/plugins/continuosDownload/DownloadOsmTask2.java
@@ -1,20 +1,25 @@
 // License: GPL. See LICENSE file for details.
 package org.openstreetmap.josm.plugins.continuosDownload;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 
 import org.openstreetmap.josm.actions.downloadtasks.DownloadOsmTask;
 import org.openstreetmap.josm.actions.downloadtasks.DownloadParams;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 import org.openstreetmap.josm.io.OsmServerReader;
+import org.openstreetmap.josm.io.OsmTransferException;
+import org.xml.sax.SAXException;
 
 /**
  * This is a copy of the DownloadOsmTask that does not change the view after the area is downloaded.
  * It still displays modal windows and ugly dialog boxes :(
  */
 public class DownloadOsmTask2 extends DownloadOsmTask {
-
     /**
      * Constructs a new {@code DownloadOsmTask2}.
      */
@@ -29,10 +34,25 @@ public class DownloadOsmTask2 extends DownloadOsmTask {
     }
 
     protected class DownloadTask2 extends DownloadTask {
-
         public DownloadTask2(DownloadParams settings, OsmServerReader reader,
                 ProgressMonitor progressMonitor) {
             super(settings, reader, progressMonitor, false);
+        }
+
+        @Override
+        public void realRun() throws OsmTransferException, IOException, SAXException {
+            // Get the current error messages
+            final List<Object> oldErrors = new ArrayList<>(DownloadOsmTask2.this.getErrorObjects());
+            // Do the actual run
+            super.realRun();
+            // Get the new error messages
+            final List<Object> newErrors = new ArrayList<>(DownloadOsmTask2.this.getErrorObjects());
+            // But we have to remove the old error messages first
+            newErrors.removeIf(oldErrors::contains);
+
+            final List<Consumer<Exception>> handlers = DownloadPlugin.getDownloadExceptionConsumers();
+            newErrors.stream().filter(Exception.class::isInstance).map(Exception.class::cast)
+                    .forEach(exception -> handlers.forEach(handler -> handler.accept(exception)));
         }
     }
 }

--- a/src/org/openstreetmap/josm/plugins/continuosDownload/DownloadOsmTask2.java
+++ b/src/org/openstreetmap/josm/plugins/continuosDownload/DownloadOsmTask2.java
@@ -33,6 +33,16 @@ public class DownloadOsmTask2 extends DownloadOsmTask {
         return download(new DownloadTask2(settings, reader, progressMonitor), downloadArea);
     }
 
+    @Override
+    protected Future<?> download(DownloadTask downloadTask, Bounds downloadArea) {
+        // This method needs to be overridden to avoid using JOSM's MainApplication.worker for downloads
+        this.downloadTask = downloadTask;
+        this.currentBounds = new Bounds(downloadArea);
+        // We need submit instead of execute so we can wait for it to finish and get the error
+        // message if necessary. If no one calls getErrorMessage() it just behaves like execute.
+        return DownloadPlugin.worker.submit(downloadTask);
+    }
+
     protected class DownloadTask2 extends DownloadTask {
         public DownloadTask2(DownloadParams settings, OsmServerReader reader,
                 ProgressMonitor progressMonitor) {

--- a/src/org/openstreetmap/josm/plugins/continuosDownload/DownloadPlugin.java
+++ b/src/org/openstreetmap/josm/plugins/continuosDownload/DownloadPlugin.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -25,12 +26,14 @@ import javax.swing.JOptionPane;
 
 import org.openstreetmap.josm.actions.JosmAction;
 import org.openstreetmap.josm.data.Bounds;
+import org.openstreetmap.josm.data.preferences.IntegerProperty;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.MainMenu;
 import org.openstreetmap.josm.gui.MapView;
 import org.openstreetmap.josm.gui.NavigatableComponent;
 import org.openstreetmap.josm.gui.NavigatableComponent.ZoomChangeListener;
 import org.openstreetmap.josm.gui.Notification;
+import org.openstreetmap.josm.gui.PleaseWaitRunnable;
 import org.openstreetmap.josm.gui.preferences.PreferenceSetting;
 import org.openstreetmap.josm.gui.util.GuiHelper;
 import org.openstreetmap.josm.io.OsmApiException;
@@ -42,20 +45,27 @@ import org.openstreetmap.josm.tools.Logging;
 import org.openstreetmap.josm.tools.Shortcut;
 
 public class DownloadPlugin extends Plugin implements ZoomChangeListener, Destroyable {
+    private static final IntegerProperty maxThreads = new IntegerProperty("plugin.continuos_download.max_threads", 2);
 
     private static final List<Consumer<Exception>> exceptionConsumers = new ArrayList<>();
 
     /**
-     * The worker that runs all our downloads, it have more threads than
+     * The worker that runs all our downloads, it has more threads than
      * {@link MainApplication#worker}.
      */
-    public static final ExecutorService worker = new ThreadPoolExecutor(1,
-            Config.getPref().getInt("plugin.continuos_download.max_threads", 2), 1, TimeUnit.SECONDS,
-            new LinkedBlockingQueue<Runnable>());
+    public static final ExecutorService worker = new ThreadPoolExecutor(
+            /*
+             * maximumPoolSize only matters when the queue is full. Which should never happen (Integer.MAX_VALUE).
+             * We will set core size to maxThreads and allow them to time out
+             */
+            maxThreads.get(), maxThreads.get(), 1, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
+            Executors.defaultThreadFactory());
     private static final HashMap<String, AbstractDownloadStrategy> strats = new HashMap<>();
     static {
         registerStrat(new SimpleStrategy());
         registerStrat(new BoxStrategy());
+        // This ensures that threads will be destroyed when not used.
+        ((ThreadPoolExecutor) worker).allowCoreThreadTimeOut(true);
     }
     private Timer timer;
     private TimerTask task;
@@ -81,6 +91,8 @@ public class DownloadPlugin extends Plugin implements ZoomChangeListener, Destro
         menuItem = MainMenu.addWithCheckbox(MainApplication.getMenu().fileMenu, toggle,
                 MainMenu.WINDOW_MENU_GROUP.ALWAYS);
         menuItem.setState(active);
+        // If the user re-enables continuousDownload, reset the zoom disabled level.
+        menuItem.addChangeListener(l -> this.zoomDisabled = null);
         toggle.addButtonModel(menuItem.getModel());
         exceptionConsumers.add(this::handleException);
     }
@@ -143,7 +155,17 @@ public class DownloadPlugin extends Plugin implements ZoomChangeListener, Destro
     private void handleException(final Exception exception) {
         if (exception instanceof OsmApiException && ((OsmApiException) exception).getErrorHeader().contains("requested too many")) {
             this.active = false;
-            this.menuItem.setSelected(false);
+            GuiHelper.runInEDT(() -> this.menuItem.setSelected(false));
+            final ThreadPoolExecutor executor = (ThreadPoolExecutor) worker;
+            // Remove anything that is currently in the queue. There are going to be a lot of PostDownloadHandler objects, which
+            // does not have cancel functionality. Unfortunately.
+            new ArrayList<>(executor.getQueue()).forEach(runnable -> {
+                executor.remove(runnable);
+                // DownloadTask is a subclass of PleaseWaitRunnable
+                if (runnable instanceof PleaseWaitRunnable) {
+                    ((PleaseWaitRunnable) runnable).operationCanceled();
+                }
+            });
             this.zoomDisabled = Optional.ofNullable(MainApplication.getMap()).map(map -> map.mapView)
                     .map(NavigatableComponent::getScale).orElse(null);
             GuiHelper.runInEDT(() -> {


### PR DESCRIPTION
This disables automatic downloads until the user zooms in (there is a
notification).

This should fix JOSM [#21485](https://josm.openstreetmap.de/ticket/21485) with respect to continousDownload.

Signed-off-by: Taylor Smock <tsmock@fb.com>