### PR TITLE
Fix #16207: continuous download plugin is not downloading notes 

### DIFF
--- a/.github/workflows/ant-release.yml
+++ b/.github/workflows/ant-release.yml
@@ -1,0 +1,14 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  call-workflow:
+    uses: JOSM/JOSMPluginAction/.github/workflows/ant.yml@v2
+    with:
+      josm-revision: "r14153"
+      perform-revision-tagging: ${{ github.repository == 'JOSM/continuos-download' && github.ref_type == 'branch' && github.ref_name == 'master' && github.event_name != 'schedule' && github.event_name != 'pull_request' && matrix.josm-revision == 'r14153' }}
+
+

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,0 +1,30 @@
+name: Java CI
+
+on:
+  push:
+    branches:
+      - master
+      - $default-branch
+      - $protected-branches
+  pull_request:
+    branches:
+      - master
+      - $default-branch
+  schedule:
+  - cron: "52 23 * * 2"
+  workflow_dispatch:
+
+jobs:
+  call-workflow:
+    strategy:
+      matrix:
+        josm-revision: ["", "r14153"]
+    uses: JOSM/JOSMPluginAction/.github/workflows/ant.yml@v2
+    with:
+      josm-revision: ${{ matrix.josm-revision }}
+      perform-revision-tagging: ${{ github.repository == 'JOSM/continuos-download' && github.ref_type == 'branch' && github.ref_name == 'master' && github.event_name != 'schedule' && github.event_name != 'pull_request' && matrix.josm-revision == 'r14153' }}
+    secrets: inherit
+    permissions:
+      checks: write
+      contents: write
+      deployments: write

--- a/.github/workflows/reports.yaml
+++ b/.github/workflows/reports.yaml
@@ -1,0 +1,13 @@
+name: Publish reports
+
+on:
+  workflow_run:
+    workflows: [Java CI]
+    types: [completed]
+
+permissions:
+  checks: write
+
+jobs:
+  call-workflow:
+    uses: JOSM/JOSMPluginAction/.github/workflows/reports.yaml@v2

--- a/build.xml
+++ b/build.xml
@@ -16,9 +16,6 @@
     <property name="plugin.link" value="https://github.com/JOSM/JOSM-continuos-download"/>
     <property name="plugin.canloadatruntime" value="true"/>
 
-	<property name="josm" location="../../core/dist/josm-custom.jar"/>
-	<property name="plugin.dist.dir" value="../../dist"/>
-
     <target name="additional-manifest">
         <manifest file="MANIFEST" mode="update">
             <attribute name="7588_Plugin-Url" value="v1.1.01;https://github.com/Gnonthgol/JOSM-continuos-download/releases/download/v1.1.01/continuosDownload.jar" />

--- a/src/org/openstreetmap/josm/plugins/continuosDownload/DownloadPreference.java
+++ b/src/org/openstreetmap/josm/plugins/continuosDownload/DownloadPreference.java
@@ -13,6 +13,7 @@ import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 
 import org.openstreetmap.josm.gui.preferences.DefaultTabPreferenceSetting;
@@ -125,6 +126,6 @@ public class DownloadPreference extends DefaultTabPreferenceSetting implements D
 
     @Override
     public void destroy() {
-        guiPanes.forEach((gui, panel) -> gui.remove(panel));
+        guiPanes.forEach(JTabbedPane::remove);
     }
 }

--- a/src/org/openstreetmap/josm/plugins/continuosDownload/Interval.java
+++ b/src/org/openstreetmap/josm/plugins/continuosDownload/Interval.java
@@ -52,10 +52,6 @@ public class Interval {
         if (!(obj instanceof Interval))
             return false;
         Interval other = (Interval) obj;
-        if (max != other.max)
-            return false;
-        if (min != other.min)
-            return false;
-        return true;
+        return max == other.max && min == other.min;
     }
 }


### PR DESCRIPTION
This doesn't completely fix the issue; JOSM core still needs to return the download area for the notes layer.